### PR TITLE
Remove vfsStream dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
     "drush/drush": "11.*@stable",
     "jcalderonzumba/gastonjs": "v1.2.0",
     "jcalderonzumba/mink-phantomjs-driver": "v0.3.3",
-    "mikey179/vfsstream": "v1.6.10",
     "mglaman/phpstan-drupal": "1.1.20",
     "phpstan/extension-installer": "1.1.0",
     "phpstan/phpstan": "1.7.14",


### PR DESCRIPTION
Although I can not find the original story in which we added it, it was added as a way to make sure that PHPUnit or Behat tests didn't fail. When we added it it was silently required by Drupal tests but not yet added. We now keep updating it but we should just get it from [Drupal's dev dependencies](https://github.com/drupal/core-dev/blob/9.0.x/composer.json#L17) since as far as I know we don't use it directly.