### PR TITLE
Update PHPStan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "mglaman/phpstan-drupal": "1.1.20",
     "mikey179/vfsstream": "^1.6.11",
     "phpstan/extension-installer": "1.1.0",
-    "phpstan/phpstan": "1.7.14",
+    "phpstan/phpstan": "~1.9.2",
     "phpstan/phpstan-deprecation-rules": "^1.0",
     "phpstan/phpstan-phpunit": "1.1.1",
     "phpspec/prophecy-phpunit": "v2.0.1",


### PR DESCRIPTION
We update to the latest version of PHPStan.

We also provide a more permissive version since PHPStan is good with semantic versioning (and we only allow patch updates).

See https://github.com/goalgorilla/open_social/pull/3256