### PR TITLE
Internal: Support Open Social 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "dmore/behat-chrome-extension": "^1.4",
     "drupal/coder": "8.3.15",
     "drupal/core-dev": "~9.4.8",
-    "drupal/devel": "5.0.2",
+    "drupal/devel": "2.1 || 5.0.2",
     "drupal/drupal-extension": "v4.2.1",
     "drush/drush": "11.*@stable",
     "friends-of-behat/mink-debug-extension": "^2.1",

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,13 @@
     "drush/drush": "10.6.2 || 11.*@stable",
     "friends-of-behat/mink-debug-extension": "^2.1",
     "mglaman/phpstan-drupal": "1.1.20",
+    "mikey179/vfsstream": "^1.6.11",
     "phpstan/extension-installer": "1.1.0",
     "phpstan/phpstan": "1.7.14",
     "phpstan/phpstan-deprecation-rules": "^1.0",
     "phpstan/phpstan-phpunit": "1.1.1",
     "phpspec/prophecy-phpunit": "v2.0.1",
-    "goalgorilla/open_social_scripts": "4.0.0"
+    "goalgorilla/open_social_scripts": "4.0.0",
+    "symfony/phpunit-bridge": "^4.4 || ^5.4 || ^6.2"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
     "dealerdirect/phpcodesniffer-composer-installer": "~0.7.1",
     "dmore/behat-chrome-extension": "^1.4",
     "drupal/coder": "8.3.15",
-    "drupal/core-dev": "~9.4.8",
     "drupal/devel": "2.1 || 5.0.2",
     "drupal/drupal-extension": "v4.2.1",
     "drush/drush": "11.*@stable",

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
     "drupal/coder": "8.3.15",
     "drupal/devel": "2.1 || 5.0.2",
     "drupal/drupal-extension": "v4.2.1",
+    "drupal/drupal-driver": "2.2.0",
     "drush/drush": "10.6.2 || 11.*@stable",
     "friends-of-behat/mink-debug-extension": "^2.1",
     "mglaman/phpstan-drupal": "1.1.20",
@@ -18,12 +19,5 @@
     "phpstan/phpstan-phpunit": "1.1.1",
     "phpspec/prophecy-phpunit": "v2.0.1",
     "goalgorilla/open_social_scripts": "4.0.0"
-  },
-  "extra": {
-    "patches": {
-      "drupal/drupal-driver": {
-        "https://github.com/jhedstrom/DrupalDriver/issues/259 - Fix taxonomy term creation": "https://github.com/jhedstrom/DrupalDriver/files/10139569/DrupalDriver-pr-260.patch.txt"
-      }
-    }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "drupal/coder": "8.3.15",
     "drupal/devel": "2.1 || 5.0.2",
     "drupal/drupal-extension": "v4.2.1",
-    "drush/drush": "11.*@stable",
+    "drush/drush": "10.6.2 || 11.*@stable",
     "friends-of-behat/mink-debug-extension": "^2.1",
     "mglaman/phpstan-drupal": "1.1.20",
     "phpstan/extension-installer": "1.1.0",

--- a/tests/composer.json
+++ b/tests/composer.json
@@ -68,6 +68,13 @@
         "type:drupal-drush"
       ]
     },
-    "enable-patching": true
+    "enable-patching": true,
+    "patches-ignore": {
+      "goalgorilla/open_social": {
+        "instaclick/php-webdriver": {
+          "Curl_exec errors on behat (1.4.10)": "https://www.drupal.org/files/issues/2021-10-17/social-instaclick-webdriver-3226058-8.patch"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
We want to test the upgrade path in Open Social so that we can be sure upgrades
from 10 -> 11 (or in the future 11 -> 12) are working correctly. 

Unfortunately we don't have a version of this package from the Open Social 10 era
so we slightly widen our version constraints so that we can also install this package 
for Open Social 10 and test our upgrade path.

- We allow a devel version that's compatible with Open Social 8 (using what we used at the time of Open Social 10)
- We remove drupal/core-dev since its purpose is to run Drupal core tests which we don't want to do. It's also closely tied to Drupal core versions, but we want our development tooling to work across update.
- We allow Drush 10 again since that's needed to install Open Social 10.

Once this PR is merged we can tag `1.0.0` of this package and create SemVer updates from there.