### PR TITLE
Ensure empty tests can be muted in Behat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,12 @@
     "phpspec/prophecy-phpunit": "v2.0.1",
     "goalgorilla/open_social_scripts": "~4.0.0",
     "symfony/phpunit-bridge": "^4.4 || ^5.4 || ^6.2"
+  },
+  "extra": {
+    "patches": {
+      "behat/behat": {
+        "PR 1420 - Allow test selection to be empty": "https://github.com/Kingdutch/Behat/commit/22b329b72b471e7db8f197c10c5852d548d502d4.diff"
+      }
+    }
   }
 }


### PR DESCRIPTION
In our CI we split out test jobs based on folder. Additionally we run each .feature file individually so we can create output test groups. However, due to how we've arranged our tags and our test matrices it could be that Behat is called with a path to a file that has all tests excluded using a tag.

The change in this PR provides an option to mute this error and prevent a CI from failing when no tests were executed deliberately.

See https://github.com/Behat/Behat/pull/1420