### PR TITLE
Update dev dependencies to be compatible with Drupal 10 and make sure we use a newer phpstan drupal version for more elaborate checks.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "dmore/behat-chrome-extension": "^1.4",
     "drupal/coder": "8.3.22",
     "drupal/devel": "5.1.2",
-    "drupal/drupal-extension": "v4.2.1 || v5.0.0rc1",
+    "drupal/drupal-extension": "v5.0.0rc1",
     "friends-of-behat/mink-debug-extension": "^2.1",
     "drush/drush": "^12",
     "mglaman/phpstan-drupal": "1.1.30",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "dealerdirect/phpcodesniffer-composer-installer": "~1.0.0",
     "dmore/behat-chrome-extension": "^1.4",
     "drupal/coder": "8.3.22",
-    "drupal/devel": "2.1 || 5.1.2",
+    "drupal/devel": "5.1.2",
     "drupal/drupal-extension": "v4.2.1 || v5.0.0rc1",
     "friends-of-behat/mink-debug-extension": "^2.1",
     "drush/drush": "^12",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "drupal/devel": "2.1 || 5.1.2",
     "drupal/drupal-extension": "v4.2.1 || v5.0.0rc1",
     "friends-of-behat/mink-debug-extension": "^2.1",
-    "drush/drush": "10.6.2 || 11.*@stable",
+    "drush/drush": "^12",
     "mglaman/phpstan-drupal": "1.1.30",
     "mikey179/vfsstream": "^1.6.11",
     "phpstan/extension-installer": "1.3.1",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "drupal/drupal-extension": "v5.0.0rc1",
     "friends-of-behat/mink-debug-extension": "^2.1",
     "drush/drush": "^12",
-    "mglaman/phpstan-drupal": "1.1.30",
+    "mglaman/phpstan-drupal": "1.2.4",
     "mikey179/vfsstream": "^1.6.11",
     "phpstan/extension-installer": "1.3.1",
     "phpstan/phpstan": "~1.10.35",


### PR DESCRIPTION
Updated to `"drush/drush": "^12"` and drop support for earlier versions.

![Screenshot 2023-11-15 at 16 49 55](https://github.com/goalgorilla/open_social_dev/assets/16667281/a444b62e-85a6-4406-be1b-99e3d4d4fca2)

Drop `drupal/devel` support for 2.1 to make sure we only use a D10 compatible version.

[Force jhedstrom/DrupalExtension version 5](https://github.com/goalgorilla/open_social_dev/commit/ac181a1ec7f7aaaa65301e28fa37a7f51916b8d3) 

And last but not least, not necessarily a D10 requirement but very helpful in our D10 efforts, is 
[Update mglaman/phpstan-drupal requirement from 1.1.30 to 1.2.4](https://github.com/goalgorilla/open_social_dev/commit/9e67cd31a98e61e223184d454001e95249714a64)

This way we can already use those updated checks for our D10 efforts.