### PR TITLE
Add Behat linting to our toolchain

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     "drupal/drupal-extension": "v5.0.0rc1",
     "friends-of-behat/mink-debug-extension": "^2.1",
     "drush/drush": "^12",
+    "kingdutch/cucumber-linter": "^0.1.0",
     "mglaman/phpstan-drupal": "1.2.4",
     "mikey179/vfsstream": "^1.6.11",
     "phpstan/extension-installer": "1.3.1",


### PR DESCRIPTION
[Cucumber Linter](github.com/Kingdutch/cucumber-linter) provides a package that can lint for certain patterns in Behat tests (such as proper indentation and order of `arrange`, `act`, and `assert` test stages. This ensures tests are written in a uniform manner making them easy for others to understand. Additionally duplication of test stages usually indicates a test should be split up.