### PR TITLE
PROD-31149: Add drupal/upgrade_status in preparation of Drupal 11 migration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     "drupal/drupal-extension": "v5.0.0rc1",
     "friends-of-behat/mink-debug-extension": "^2.1",
     "drush/drush": "^12",
+    "drupal/upgrade_status":"^4.3",
     "kingdutch/cucumber-linter": "^0.1.0",
     "mglaman/phpstan-drupal": "1.2.4",
     "mikey179/vfsstream": "^1.6.11",

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "kingdutch/cucumber-linter": "^0.1.0",
     "mglaman/phpstan-drupal": "1.2.4",
     "mikey179/vfsstream": "^1.6.11",
+    "palantirnet/drupal-rector": "^0.20.3",
     "phpstan/extension-installer": "1.3.1",
     "phpstan/phpstan": "~1.10.35",
     "phpstan/phpstan-deprecation-rules": "^1.0",


### PR DESCRIPTION
Add drupal/upgrade_status in preparation of Drupal 11 migration.
https://getopensocial.atlassian.net/browse/PROD-31069