### PR TITLE
PROD-31945: Add shipmonk/phpstan-baseline-per-identifier to dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "phpstan/phpstan-phpunit": "^2.0",
     "phpspec/prophecy-phpunit": "v2.0.2",
     "goalgorilla/open_social_scripts": "~4.0.0",
-    "shipmonk/phpstan-baseline-per-identifier": "1.0.0",
+    "shipmonk/phpstan-baseline-per-identifier": "^2.0",
     "symfony/phpunit-bridge": "^4.4 || ^5.4 || ^6.2 || ^7.0"
   },
   "extra": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
     "drupal/drupal-extension": "^v5.0.0rc1 || v5.1.0",
     "friends-of-behat/mink-debug-extension": "^2.1",
     "drush/drush": "^12 | ^13",
-    "drupal/upgrade_status":"^4.3",
     "jangregor/phpstan-prophecy": "^2.0",
     "kingdutch/cucumber-linter": "^0.1.0",
     "mglaman/phpstan-drupal": "^2.0.0",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
     "kingdutch/cucumber-linter": "^0.1.0",
     "mglaman/phpstan-drupal": "^2.0.0",
     "mikey179/vfsstream": "^1.6.11",
-    "palantirnet/drupal-rector": "^0.20.3",
     "phpstan/extension-installer": "^1.3.1 || ^1.4.3",
     "phpstan/phpstan": "^2",
     "phpstan/phpstan-deprecation-rules": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "palantirnet/drupal-rector": "^0.20.3",
     "phpstan/extension-installer": "^1.3.1 || ^1.4.3",
     "phpstan/phpstan": "^2",
-    "phpstan/phpstan-deprecation-rules": "^1.0",
+    "phpstan/phpstan-deprecation-rules": "^2.0",
     "phpstan/phpstan-phpunit": "1.3.15",
     "phpspec/prophecy-phpunit": "v2.0.2",
     "goalgorilla/open_social_scripts": "~4.0.0",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "mikey179/vfsstream": "^1.6.11",
     "palantirnet/drupal-rector": "^0.20.3",
     "phpstan/extension-installer": "^1.3.1 || ^1.4.3",
-    "phpstan/phpstan": "~1.10.35",
+    "phpstan/phpstan": "1.15.1",
     "phpstan/phpstan-deprecation-rules": "^1.0",
     "phpstan/phpstan-phpunit": "1.3.15",
     "phpspec/prophecy-phpunit": "v2.0.2",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "mikey179/vfsstream": "^1.6.11",
     "palantirnet/drupal-rector": "^0.20.3",
     "phpstan/extension-installer": "^1.3.1 || ^1.4.3",
-    "phpstan/phpstan": "1.15.1",
+    "phpstan/phpstan": "^2",
     "phpstan/phpstan-deprecation-rules": "^1.0",
     "phpstan/phpstan-phpunit": "1.3.15",
     "phpspec/prophecy-phpunit": "v2.0.2",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "phpstan/extension-installer": "^1.3.1 || ^1.4.3",
     "phpstan/phpstan": "^2",
     "phpstan/phpstan-deprecation-rules": "^2.0",
-    "phpstan/phpstan-phpunit": "1.3.15",
+    "phpstan/phpstan-phpunit": "^2.0",
     "phpspec/prophecy-phpunit": "v2.0.2",
     "goalgorilla/open_social_scripts": "~4.0.0",
     "shipmonk/phpstan-baseline-per-identifier": "1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "drupal/upgrade_status":"^4.3",
     "jangregor/phpstan-prophecy": "^2.0",
     "kingdutch/cucumber-linter": "^0.1.0",
-    "mglaman/phpstan-drupal": "1.2.4",
+    "mglaman/phpstan-drupal": "^2.0.0",
     "mikey179/vfsstream": "^1.6.11",
     "palantirnet/drupal-rector": "^0.20.3",
     "phpstan/extension-installer": "^1.3.1 || ^1.4.3",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "friends-of-behat/mink-debug-extension": "^2.1",
     "drush/drush": "^12 | ^13",
     "drupal/upgrade_status":"^4.3",
-    "jangregor/phpstan-prophecy": "^1.0",
+    "jangregor/phpstan-prophecy": "^2.0",
     "kingdutch/cucumber-linter": "^0.1.0",
     "mglaman/phpstan-drupal": "1.2.4",
     "mikey179/vfsstream": "^1.6.11",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "phpstan/phpstan-phpunit": "1.3.15",
     "phpspec/prophecy-phpunit": "v2.0.2",
     "goalgorilla/open_social_scripts": "~4.0.0",
-    "shipmonk/phpstan-baseline-per-identifier": "2.1.3",
+    "shipmonk/phpstan-baseline-per-identifier": "1.0.0",
     "symfony/phpunit-bridge": "^4.4 || ^5.4 || ^6.2 || ^7.0"
   },
   "extra": {

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     "phpstan/phpstan-phpunit": "1.3.15",
     "phpspec/prophecy-phpunit": "v2.0.2",
     "goalgorilla/open_social_scripts": "~4.0.0",
+    "shipmonk/phpstan-baseline-per-identifier": "2.1.3",
     "symfony/phpunit-bridge": "^4.4 || ^5.4 || ^6.2 || ^7.0"
   },
   "extra": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
     "drupal/drupal-extension": "^v5.0.0rc1 || v5.1.0",
     "friends-of-behat/mink-debug-extension": "^2.1",
     "drush/drush": "^12 | ^13",
-    "jangregor/phpstan-prophecy": "^2.0",
     "kingdutch/cucumber-linter": "^0.1.0",
     "mglaman/phpstan-drupal": "^2.0.0",
     "mikey179/vfsstream": "^1.6.11",


### PR DESCRIPTION
To improve the management of the phpstan ignore file, we want to add shipmonk/phpstan-baseline-per-identifier to split the initial file into smaller files.
The final goal will be to be able to do small PR to fix these issues.